### PR TITLE
fixes in install for cross-compiling

### DIFF
--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(lifecycle)
 
-find_package(catkin REQUIRED
+find_package(catkin2 REQUIRED
   COMPONENTS
   roscpp
   rostest


### PR DESCRIPTION
keeping this as Draft for now because: the rootfs making isn't working at the moment (Ruben will fix it Friday), so I can't finish the cross compile because I can't add the package `ros-noetic-behaviortree-cpp`. Brian K will also remove that dependency, so whatever happens first.